### PR TITLE
Added thumbnail cropping and some additional hotkey cycle groups

### DIFF
--- a/README.md
+++ b/README.md
@@ -132,6 +132,7 @@ Some of the application options are not exposed in the GUI. They can be adjusted
 | **ThumbnailMinimumSize** | <div style="font-size: small">Minimum thumbnail size that can be set either via GUI or by resizing a thumbnail window. Value is written in the form "width, height"<br />The default value is **"100, 80"**.<br />For example: **"ThumbnailMinimumSize": "100, 80"**</div> |
 | **ThumbnailMaximumSize** | <div style="font-size: small">Maximum thumbnail size that can be set either via GUI or by resizing a thumbnail window. Value is written in the form "width, height"<br />The default value is **"640, 400"**.<br />For example: **"ThumbnailMaximumSize": "640, 400"**</div> |
 | **ThumbnailRefreshPeriod** | <div style="font-size: small">Thumbnail refresh period in milliseconds. This option accepts values between **300** and **1000** only.<br />The default value is **500** milliseconds.<br />For example: **"ThumbnailRefreshPeriod": 500**</div> |
+| **ClientCrop** | <div style="font-size: small">Specify cropping options for thumbnail capture.<br />This does nothing unless explicitly configured, however you can specify a global value to apply to all clients.<br />For example: **"ClientCrop": { "EVE - Awox": "45, 43, 1600, 1360" }** for just Awox, or<br>for all clients: **"ClientCrop": { "*": "45, 43, 1600, 1360" }**</div> |
 
 <div style="page-break-after: always;"></div>
 
@@ -198,7 +199,7 @@ You should modify this entry with a list of each of your clients replacing "Exam
 If a character appears in the list but is not currently logged in, then it will simply be skipped.
 If a character does not appear in the list, then they will never become active when cycling clients.
 
-By now you may have noticed that there are two groups. The above configuration can be followed for a second group by using the values **CycleGroup2ForwardHotkeys**, **CycleGroup2BackwardHotkeys**, and **CycleGroup2ForwardHotkeys**
+By now you may have noticed that there are four groups. The above configuration can be followed for a second group by using the values **CycleGroup2ForwardHotkeys**, **CycleGroup2BackwardHotkeys**, and **CycleGroup2ForwardHotkeys** or a fourth group using **CycleGroup4ForwardHotkeys** etc.
 This may provide useful if you want to have one HotKey to cycle through a group of DPS characters, while another HotKey cycles through support roles such as gate scouts, or a group of logi.
 
 Alternatively you may not want to use any of these HotKeys. Please note that deleting the values in their entirety will simply result in them being automatically re-generated.
@@ -210,6 +211,12 @@ Should you wish to remove these HotKeys completely, Simply set the values to emp
 	  "CycleGroup2ForwardHotkeys": [],
 	  "CycleGroup2BackwardHotkeys": [],
 	  "CycleGroup2ClientsOrder": {}
+      "CycleGroup3ForwardHotkeys": [],
+	  "CycleGroup3BackwardHotkeys": [],
+	  "CycleGroup3ClientsOrder": {},
+	  "CycleGroup4ForwardHotkeys": [],
+	  "CycleGroup4BackwardHotkeys": [],
+	  "CycleGroup4ClientsOrder": {}
 
 **Hints** 
 * Minimise the use of modifiers or standard keys to minimise issues with the client playing up. In the default example unusual Function keys (e.g. F14) are used which are then bound to a game pad or gaming mouse.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,15 @@
+
+## Notes from Awox
+
+<div style="color:red; font-weight:bold">Please read this section carefully!!</div>
+
+* It's not yet clear if the crop feature is permissable by CCP. I don't see why it wouldn't, given it is very common for people to use ISBoxer to generate multiple cropped displays (which are even clickable). 
+* There are some bugs that I haven't figured out how to fix yet, namely:
+  * When initially launching, thumbnail labels and stylings are not applied (this is a pre-existing bug). I just deal with it and hover over each thumbnail to get the labels and styles to apply.
+  * Somewhere thumbnail sizes get messed up, I think in `ApplyRestrictions()` somewhere but I'm not really sure. For the time being I just make sure **ThumbnailSize**, **ThumbnailMinimumSize** and **ThumbnailMaximumSize** are all set to the same value.
+  
+<hr>
+
 ## Overview
 
 The purpose of this application is to provide a simple way to keep an eye on several simultaneously running EVE Online clients and to easily switch between them. While running it shows a set of live thumbnails for each of the active EVE Online clients. These thumbnails allow fast switch to the corresponding EVE Online client either using mouse or configurable hotkeys.
@@ -7,7 +19,7 @@ It's essentially a task switcher, it does not relay any keyboard/mouse events an
 The program does NOT (and will NOT ever) do the following things:
 
 * modify EVE Online interface
-* display modified EVE Online interface
+* <strike>display modified EVE Online interface</strike> <i>oops - Awox</i>
 * broadcast any keyboard or mouse events
 * anyhow interact with EVE Online except of bringing its main window to foreground or resizing/minimizing it
 
@@ -133,6 +145,16 @@ Some of the application options are not exposed in the GUI. They can be adjusted
 | **ThumbnailMaximumSize** | <div style="font-size: small">Maximum thumbnail size that can be set either via GUI or by resizing a thumbnail window. Value is written in the form "width, height"<br />The default value is **"640, 400"**.<br />For example: **"ThumbnailMaximumSize": "640, 400"**</div> |
 | **ThumbnailRefreshPeriod** | <div style="font-size: small">Thumbnail refresh period in milliseconds. This option accepts values between **300** and **1000** only.<br />The default value is **500** milliseconds.<br />For example: **"ThumbnailRefreshPeriod": 500**</div> |
 | **ClientCrop** | <div style="font-size: small">Specify cropping options for thumbnail capture.<br />This does nothing unless explicitly configured, however you can specify a global value to apply to all clients.<br />For example: **"ClientCrop": { "EVE - Awox": "45, 43, 1600, 1360" }** for just Awox, or<br>for all clients: **"ClientCrop": { "*": "45, 43, 1600, 1360" }**</div> |
+| **LabelVerticalAlign** | <div style="font-size: small">Vertical alignment of label on thumbnails<br/>The default value is <b>Top</b>. Accepted values are Top and Bottom.</div> |
+| **LabelHorizontalAlign** | <div style="font-size: small">Horizontal alignment of label on thumbnails<br/>The default value is <b>Center</b>. Accepted values are Left, Right and Center.</div> |
+| **LabelFontSize** | <div style="font-size: small">Font size to use for label on thumbnails<br/>The default value is <b>14</b>.</div> |
+| **LabelFontName** | <div style="font-size: small">Font family to use for label on thumbnails<br/>The default value is <b>Consolas</b>.</div> |
+| **LabelForeground** | <div style="font-size: small">Color of the text of the label on thumbnails<br/>The default value is <b>#000000</b>. There is also **LabelForegroundActive** which applies when the preview is highlighted. <br/>If a non hexidecimal value is supplied, a default value will be used. </div> | |
+| **LabelBackground** | <div style="font-size: small">Color of the background of the label on thumbnails<br/>The default value is <b>#000000</b>. There is also **LabelBackgroundActive** which applies when the preview is highlighted.<br/>If a non hexidecimal value is supplied, a default value will be used. </div> |
+| **PaddingWidth** | <div style="font-size: small">Border width to draw inside the window<br/>The default value is <b>2</b>. There is also **PaddingWidthActive** which applies when the preview is highlighted.</div> | |
+| **PaddingColor** | <div style="font-size: small">Color of border drawn on top of thumbnails<br/>The default value is <b>#222222</b>. There is also **PaddingColorActive** which applies when the preview is highlighted.</div> |
+
+The original thumbnail highlighting will not work if you have **PaddingWidth**/**PaddingWidthActive** set.
 
 <div style="page-break-after: always;"></div>
 

--- a/src/Eve-O-Mock/App.config
+++ b/src/Eve-O-Mock/App.config
@@ -1,6 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/>
     </startup>
 </configuration>

--- a/src/Eve-O-Mock/Eve-O-Mock.csproj
+++ b/src/Eve-O-Mock/Eve-O-Mock.csproj
@@ -9,10 +9,11 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>EveOMock</RootNamespace>
     <AssemblyName>ExeFile</AssemblyName>
-    <TargetFrameworkVersion>v4.5</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{60dc8134-eba5-43b8-bcc9-bb4bc16c2548};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <WarningLevel>4</WarningLevel>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>

--- a/src/Eve-O-Mock/Properties/Resources.Designer.cs
+++ b/src/Eve-O-Mock/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace EveOMock.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "4.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {

--- a/src/Eve-O-Mock/Properties/Settings.Designer.cs
+++ b/src/Eve-O-Mock/Properties/Settings.Designer.cs
@@ -12,7 +12,7 @@ namespace EveOMock.Properties {
     
     
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "14.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("Microsoft.VisualStudio.Editors.SettingsDesigner.SettingsSingleFileGenerator", "17.6.0.0")]
     internal sealed partial class Settings : global::System.Configuration.ApplicationSettingsBase {
         
         private static Settings defaultInstance = ((Settings)(global::System.Configuration.ApplicationSettingsBase.Synchronized(new Settings())));

--- a/src/Eve-O-Preview/Configuration/Implementation/ThumbnailConfiguration.cs
+++ b/src/Eve-O-Preview/Configuration/Implementation/ThumbnailConfiguration.cs
@@ -18,6 +18,19 @@ namespace EveOPreview.Configuration.Implementation
 		{
 			this.ConfigVersion = 1;
 
+            this.LabelForeground = "#888888";
+            this.LabelBackgroundActive = "#111111";
+            this.LabelBackground = "transparent";
+            this.LabelForegroundActive = "#FFFFFF";
+            this.LabelHorizontalAlign = "Center";
+			this.LabelVerticalAlign = "Top";
+			this.PaddingWidth = 2;
+			this.PaddingWidthActive = 2;
+			this.PaddingColor = "#111111";
+			this.PaddingColorActive = "#FFFFFF";
+			this.LabelFontSize = 16;
+            this.LabelFontName = "Consolas";
+
             this.CycleGroup1ForwardHotkeys = new List<string> { "F14", "Control+F14" };
             this.CycleGroup1BackwardHotkeys = new List<string> { "F13", "Control+F13" };
             this.CycleGroup1ClientsOrder = new Dictionary<string, int>
@@ -102,10 +115,48 @@ namespace EveOPreview.Configuration.Implementation
 			this.ActiveClientHighlightThickness = 3;
 
 			this.LoginThumbnailLocation = new Point(5, 5);
-		}
+        }
 
 
-		[JsonProperty("ConfigVersion")]
+        [JsonProperty("PaddingWidth")]
+        public int PaddingWidth { get; set; }
+
+        [JsonProperty("PaddingWidthActive")]
+        public int PaddingWidthActive { get; set; }
+
+        [JsonProperty("PaddingColor")]
+        public string PaddingColor { get; set; }
+
+        [JsonProperty("PaddingColorActive")]
+        public string PaddingColorActive { get; set; }
+
+        [JsonProperty("LabelVerticalAlign")]
+        public string LabelVerticalAlign { get; set; }
+
+        [JsonProperty("LabelHorizontalAlign")]
+        public string LabelHorizontalAlign { get; set; }
+
+        [JsonProperty("LabelFontName")]
+        public string LabelFontName { get; set; }
+
+        [JsonProperty("LabelFontSize")]
+        public int LabelFontSize { get; set; }
+
+        [JsonProperty("LabelBackgroundActive")]
+        public string LabelBackgroundActive { get; set; }
+
+        [JsonProperty("LabelForegroundActive")]
+        public string LabelForegroundActive { get; set; }
+
+
+        [JsonProperty("LabelBackground")]
+        public string LabelBackground { get; set; }
+
+        [JsonProperty("LabelForeground")]
+        public string LabelForeground { get; set; }
+
+
+        [JsonProperty("ConfigVersion")]
 		public int ConfigVersion { get; set; }
 
 		[JsonProperty("CycleGroup1ForwardHotkeys")]

--- a/src/Eve-O-Preview/Configuration/Implementation/ThumbnailConfiguration.cs
+++ b/src/Eve-O-Preview/Configuration/Implementation/ThumbnailConfiguration.cs
@@ -2,6 +2,7 @@
 using System.Drawing;
 using System.Linq;
 using System.Windows.Forms;
+using EveOPreview.Services.Interop;
 using Newtonsoft.Json;
 
 namespace EveOPreview.Configuration.Implementation
@@ -17,25 +18,43 @@ namespace EveOPreview.Configuration.Implementation
 		{
 			this.ConfigVersion = 1;
 
-			this.CycleGroup1ForwardHotkeys = new List<string> { "F14", "Control+F14" };
-			this.CycleGroup1BackwardHotkeys = new List<string> { "F13", "Control+F13" };
-			this.CycleGroup1ClientsOrder = new Dictionary<string, int>
-			{
-				{ "EVE - Example DPS Toon 1", 1 },
-				{ "EVE - Example DPS Toon 2", 2 },
-				{ "EVE - Example DPS Toon 3", 3 }
-			};
+            this.CycleGroup1ForwardHotkeys = new List<string> { "F14", "Control+F14" };
+            this.CycleGroup1BackwardHotkeys = new List<string> { "F13", "Control+F13" };
+            this.CycleGroup1ClientsOrder = new Dictionary<string, int>
+            {
+                { "EVE - Example DPS Toon 1", 1 },
+                { "EVE - Example DPS Toon 2", 2 },
+                { "EVE - Example DPS Toon 3", 3 }
+            };
 
-			this.CycleGroup2ForwardHotkeys = new List<string> { "F16", "Control+F16" };
-			this.CycleGroup2BackwardHotkeys = new List<string> { "F15", "Control+F15" };
-			this.CycleGroup2ClientsOrder = new Dictionary<string, int>
-			{
-				{ "EVE - Example Logi Toon 1", 1 },
-				{ "EVE - Example Scout Toon 2", 2 },
-				{ "EVE - Example Tackle Toon 3", 3 }
-			};
+            this.CycleGroup2ForwardHotkeys = new List<string> { "F16", "Control+F16" };
+            this.CycleGroup2BackwardHotkeys = new List<string> { "F15", "Control+F15" };
+            this.CycleGroup2ClientsOrder = new Dictionary<string, int>
+            {
+                { "EVE - Example Logi Toon 1", 1 },
+                { "EVE - Example Scout Toon 2", 2 },
+                { "EVE - Example Tackle Toon 3", 3 }
+            };
 
-			this.PerClientActiveClientHighlightColor = new Dictionary<string, Color>
+            this.CycleGroup3ForwardHotkeys = new List<string> { "F14", "Control+F18" };
+            this.CycleGroup3BackwardHotkeys = new List<string> { "F13", "Control+F17" };
+            this.CycleGroup3ClientsOrder = new Dictionary<string, int>
+            {
+                { "EVE - Example DPS Toon 4", 1 },
+                { "EVE - Example DPS Toon 5", 2 },
+                { "EVE - Example DPS Toon 6", 3 }
+            };
+
+            this.CycleGroup4ForwardHotkeys = new List<string> { "F16", "Control+F20" };
+            this.CycleGroup4BackwardHotkeys = new List<string> { "F15", "Control+F19" };
+            this.CycleGroup4ClientsOrder = new Dictionary<string, int>
+            {
+                { "EVE - Example Logi Toon 4", 1 },
+                { "EVE - Example Scout Toon 5", 2 },
+                { "EVE - Example Tackle Toon 6", 3 }
+            };
+
+            this.PerClientActiveClientHighlightColor = new Dictionary<string, Color>
 			{
 				{"EVE - Example Toon 1", Color.Red},
 				{"EVE - Example Toon 2", Color.Green}
@@ -43,8 +62,9 @@ namespace EveOPreview.Configuration.Implementation
 
 			this.PerClientLayout = new Dictionary<string, Dictionary<string, Point>>();
 			this.FlatLayout = new Dictionary<string, Point>();
-			this.ClientLayout = new Dictionary<string, ClientLayout>();
-			this.ClientHotkey = new Dictionary<string, string>();
+            this.ClientLayout = new Dictionary<string, ClientLayout>();
+            this.ClientCrop = new Dictionary<string, Rectangle>();
+            this.ClientHotkey = new Dictionary<string, string>();
 			this.DisableThumbnail = new Dictionary<string, bool>();
 			this.PriorityClients = new List<string>();
 
@@ -97,16 +117,34 @@ namespace EveOPreview.Configuration.Implementation
 		[JsonProperty("CycleGroup1ClientsOrder")]
 		public Dictionary<string, int> CycleGroup1ClientsOrder { get; set; }
 
-		[JsonProperty("CycleGroup2ForwardHotkeys")]
-		public List<string> CycleGroup2ForwardHotkeys { get; set; }
+        [JsonProperty("CycleGroup2ForwardHotkeys")]
+        public List<string> CycleGroup2ForwardHotkeys { get; set; }
 
-		[JsonProperty("CycleGroup2BackwardHotkeys")]
-		public List<string> CycleGroup2BackwardHotkeys { get; set; }
+        [JsonProperty("CycleGroup2BackwardHotkeys")]
+        public List<string> CycleGroup2BackwardHotkeys { get; set; }
 
-		[JsonProperty("CycleGroup2ClientsOrder")]
-		public Dictionary<string, int> CycleGroup2ClientsOrder { get; set; }
+        [JsonProperty("CycleGroup2ClientsOrder")]
+        public Dictionary<string, int> CycleGroup2ClientsOrder { get; set; }
 
-		[JsonProperty("PerClientActiveClientHighlightColor")]
+        [JsonProperty("CycleGroup3ForwardHotkeys")]
+        public List<string> CycleGroup3ForwardHotkeys { get; set; }
+
+        [JsonProperty("CycleGroup3BackwardHotkeys")]
+        public List<string> CycleGroup3BackwardHotkeys { get; set; }
+
+        [JsonProperty("CycleGroup3ClientsOrder")]
+        public Dictionary<string, int> CycleGroup3ClientsOrder { get; set; }
+
+        [JsonProperty("CycleGroup4ForwardHotkeys")]
+        public List<string> CycleGroup4ForwardHotkeys { get; set; }
+
+        [JsonProperty("CycleGroup4BackwardHotkeys")]
+        public List<string> CycleGroup4BackwardHotkeys { get; set; }
+
+        [JsonProperty("CycleGroup4ClientsOrder")]
+        public Dictionary<string, int> CycleGroup4ClientsOrder { get; set; }
+
+        [JsonProperty("PerClientActiveClientHighlightColor")]
 		public Dictionary<string, Color> PerClientActiveClientHighlightColor { get; set; }
 
 		public bool MinimizeToTray { get; set; }
@@ -181,9 +219,11 @@ namespace EveOPreview.Configuration.Implementation
 		[JsonProperty]
 		private Dictionary<string, Point> FlatLayout { get; set; }
 		[JsonProperty]
-		private Dictionary<string, ClientLayout> ClientLayout { get; set; }
-		[JsonProperty]
-		private Dictionary<string, string> ClientHotkey { get; set; }
+        private Dictionary<string, ClientLayout> ClientLayout { get; set; }
+        [JsonProperty]
+        private Dictionary<string, Rectangle> ClientCrop{ get; set; }
+        [JsonProperty]
+        private Dictionary<string, string> ClientHotkey { get; set; }
 		[JsonProperty]
 		private Dictionary<string, bool> DisableThumbnail { get; set; }
 		[JsonProperty]
@@ -236,17 +276,24 @@ namespace EveOPreview.Configuration.Implementation
 			}
 
 			layoutSource[currentClient] = location;
-		}
+        }
 
-		public ClientLayout GetClientLayout(string currentClient)
-		{
-			ClientLayout layout;
-			this.ClientLayout.TryGetValue(currentClient, out layout);
+        public ClientLayout GetClientLayout(string currentClient)
+        {
+            ClientLayout layout;
+            this.ClientLayout.TryGetValue(currentClient, out layout);
 
-			return layout;
-		}
+            return layout;
+        }
 
-		public void SetClientLayout(string currentClient, ClientLayout layout)
+        public Rectangle GetClientCrop(string currentClient)
+        {
+            Rectangle crop;
+            this.ClientCrop.TryGetValue(currentClient, out crop);
+            return crop;
+        }
+
+        public void SetClientLayout(string currentClient, ClientLayout layout)
 		{
 			this.ClientLayout[currentClient] = layout;
 		}

--- a/src/Eve-O-Preview/Configuration/Interface/IThumbnailConfiguration.cs
+++ b/src/Eve-O-Preview/Configuration/Interface/IThumbnailConfiguration.cs
@@ -41,7 +41,22 @@ namespace EveOPreview.Configuration
 		bool HideThumbnailsOnLostFocus { get; set; }
 		int HideThumbnailsDelay { get; set; }
 
-		Size ThumbnailSize { get; set; }
+        string LabelVerticalAlign { get; set; }
+        string LabelHorizontalAlign { get; set; }
+		string LabelFontName { get; set; }
+		int LabelFontSize { get; set; }
+        string LabelBackground { get; set; }
+        string LabelForeground { get; set; }
+        string LabelBackgroundActive { get; set; }
+        string LabelForegroundActive { get; set; }
+
+
+        int PaddingWidth { get; set; }
+        int PaddingWidthActive { get; set; }
+        string PaddingColor { get; set; }
+        string PaddingColorActive { get; set; }
+
+        Size ThumbnailSize { get; set; }
 		Size ThumbnailMinimumSize { get; set; }
 		Size ThumbnailMaximumSize { get; set; }
 

--- a/src/Eve-O-Preview/Configuration/Interface/IThumbnailConfiguration.cs
+++ b/src/Eve-O-Preview/Configuration/Interface/IThumbnailConfiguration.cs
@@ -1,4 +1,5 @@
-﻿using System.Collections.Generic;
+﻿using EveOPreview.Services.Interop;
+using System.Collections.Generic;
 using System.Drawing;
 using System.Windows.Forms;
 
@@ -10,11 +11,19 @@ namespace EveOPreview.Configuration
 		List<string> CycleGroup1BackwardHotkeys { get; set; }
 		Dictionary<string, int> CycleGroup1ClientsOrder { get; set; }
 
-		List<string> CycleGroup2ForwardHotkeys { get; set; }
-		List<string> CycleGroup2BackwardHotkeys { get; set; }
-		Dictionary<string, int> CycleGroup2ClientsOrder { get; set; }
+        List<string> CycleGroup2ForwardHotkeys { get; set; }
+        List<string> CycleGroup2BackwardHotkeys { get; set; }
+        Dictionary<string, int> CycleGroup2ClientsOrder { get; set; }
 
-		Dictionary<string, Color> PerClientActiveClientHighlightColor { get; set; }
+        List<string> CycleGroup3ForwardHotkeys { get; set; }
+        List<string> CycleGroup3BackwardHotkeys { get; set; }
+        Dictionary<string, int> CycleGroup3ClientsOrder { get; set; }
+
+        List<string> CycleGroup4ForwardHotkeys { get; set; }
+        List<string> CycleGroup4BackwardHotkeys { get; set; }
+        Dictionary<string, int> CycleGroup4ClientsOrder { get; set; }
+
+        Dictionary<string, Color> PerClientActiveClientHighlightColor { get; set; }
 
 		bool MinimizeToTray { get; set; }
 		int ThumbnailRefreshPeriod { get; set; }
@@ -53,6 +62,8 @@ namespace EveOPreview.Configuration
 
 		Point GetThumbnailLocation(string currentClient, string activeClient, Point defaultLocation);
 		void SetThumbnailLocation(string currentClient, string activeClient, Point location);
+
+		Rectangle GetClientCrop(string currentClient);
 
 		ClientLayout GetClientLayout(string currentClient);
 		void SetClientLayout(string currentClient, ClientLayout layout);

--- a/src/Eve-O-Preview/Eve-O-Preview.csproj
+++ b/src/Eve-O-Preview/Eve-O-Preview.csproj
@@ -10,7 +10,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>EveOPreview</RootNamespace>
     <AssemblyName>EVE-O Preview</AssemblyName>
-    <TargetFrameworkVersion>v4.6.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <NuGetPackageImportStamp>
     </NuGetPackageImportStamp>
     <TargetFrameworkProfile />

--- a/src/Eve-O-Preview/Properties/Resources.Designer.cs
+++ b/src/Eve-O-Preview/Properties/Resources.Designer.cs
@@ -19,7 +19,7 @@ namespace EveOPreview.Properties {
     // class via a tool like ResGen or Visual Studio.
     // To add or remove a member, edit your .ResX file then rerun ResGen
     // with the /str option, or rebuild your VS project.
-    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "15.0.0.0")]
+    [global::System.CodeDom.Compiler.GeneratedCodeAttribute("System.Resources.Tools.StronglyTypedResourceBuilder", "17.0.0.0")]
     [global::System.Diagnostics.DebuggerNonUserCodeAttribute()]
     [global::System.Runtime.CompilerServices.CompilerGeneratedAttribute()]
     internal class Resources {

--- a/src/Eve-O-Preview/Services/Implementation/ThumbnailManager.cs
+++ b/src/Eve-O-Preview/Services/Implementation/ThumbnailManager.cs
@@ -79,9 +79,16 @@ namespace EveOPreview.Services
 			RegisterCycleClientHotkey(this._configuration.CycleGroup1ForwardHotkeys?.Select(x => this._configuration.StringToKey(x)), true, this._configuration.CycleGroup1ClientsOrder);
 			RegisterCycleClientHotkey(this._configuration.CycleGroup1BackwardHotkeys?.Select(x => this._configuration.StringToKey(x)), false, this._configuration.CycleGroup1ClientsOrder);
 
-			RegisterCycleClientHotkey(this._configuration.CycleGroup2ForwardHotkeys?.Select(x => this._configuration.StringToKey(x)), true, this._configuration.CycleGroup2ClientsOrder);
-			RegisterCycleClientHotkey(this._configuration.CycleGroup2BackwardHotkeys?.Select(x => this._configuration.StringToKey(x)), false, this._configuration.CycleGroup2ClientsOrder);
-		}
+            RegisterCycleClientHotkey(this._configuration.CycleGroup2ForwardHotkeys?.Select(x => this._configuration.StringToKey(x)), true, this._configuration.CycleGroup2ClientsOrder);
+            RegisterCycleClientHotkey(this._configuration.CycleGroup2BackwardHotkeys?.Select(x => this._configuration.StringToKey(x)), false, this._configuration.CycleGroup2ClientsOrder);
+
+            RegisterCycleClientHotkey(this._configuration.CycleGroup3ForwardHotkeys?.Select(x => this._configuration.StringToKey(x)), true, this._configuration.CycleGroup3ClientsOrder);
+            RegisterCycleClientHotkey(this._configuration.CycleGroup3BackwardHotkeys?.Select(x => this._configuration.StringToKey(x)), false, this._configuration.CycleGroup3ClientsOrder);
+
+            RegisterCycleClientHotkey(this._configuration.CycleGroup4ForwardHotkeys?.Select(x => this._configuration.StringToKey(x)), true, this._configuration.CycleGroup4ClientsOrder);
+            RegisterCycleClientHotkey(this._configuration.CycleGroup4BackwardHotkeys?.Select(x => this._configuration.StringToKey(x)), false, this._configuration.CycleGroup4ClientsOrder);
+
+        }
 
 		public IThumbnailView GetClientByTitle(string title)
 		{

--- a/src/Eve-O-Preview/Services/Implementation/WindowManager.cs
+++ b/src/Eve-O-Preview/Services/Implementation/WindowManager.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Drawing;
 using System.Runtime.InteropServices;
+using EveOPreview.Configuration;
 using EveOPreview.Services.Interop;
 
 namespace EveOPreview.Services.Implementation
@@ -9,10 +10,12 @@ namespace EveOPreview.Services.Implementation
 	{
 		#region Private constants
 		private const int WINDOW_SIZE_THRESHOLD = 300;
-		#endregion
+        private IThumbnailConfiguration _config;
+        #endregion
 
-		public WindowManager()
+        public WindowManager(IThumbnailConfiguration config)
 		{
+			this._config = config;
 			// Composition is always enabled for Windows 8+
 			this.IsCompositionEnabled = 
 				((Environment.OSVersion.Version.Major == 6) && (Environment.OSVersion.Version.Minor >= 2)) // Win 8 and Win 8.1
@@ -85,7 +88,7 @@ namespace EveOPreview.Services.Implementation
 
 		public IDwmThumbnail GetLiveThumbnail(IntPtr destination, IntPtr source)
 		{
-			IDwmThumbnail thumbnail = new DwmThumbnail(this);
+			IDwmThumbnail thumbnail = new DwmThumbnail(this, _config);
 			thumbnail.Register(destination, source);
 
 			return thumbnail;

--- a/src/Eve-O-Preview/View/Implementation/ThumbnailOverlay.Designer.cs
+++ b/src/Eve-O-Preview/View/Implementation/ThumbnailOverlay.Designer.cs
@@ -1,4 +1,6 @@
-﻿namespace EveOPreview.View
+﻿using System.Drawing;
+
+namespace EveOPreview.View
 {
 	partial class ThumbnailOverlay
 	{
@@ -29,8 +31,14 @@
 		private void InitializeComponent()
 		{
 			System.Windows.Forms.PictureBox OverlayAreaPictureBox;
-			this.OverlayLabel = new System.Windows.Forms.Label();
-			OverlayAreaPictureBox = new System.Windows.Forms.PictureBox();
+            this.OverlayLabel = new System.Windows.Forms.Label();
+
+
+
+
+
+
+            OverlayAreaPictureBox = new System.Windows.Forms.PictureBox();
 			((System.ComponentModel.ISupportInitialize)(OverlayAreaPictureBox)).BeginInit();
 			this.SuspendLayout();
 			// 
@@ -65,8 +73,20 @@
 			this.BackColor = System.Drawing.Color.Black;
 			this.ClientSize = new System.Drawing.Size(284, 262);
 			this.ControlBox = false;
-			this.Controls.Add(this.OverlayLabel);
-			this.Controls.Add(OverlayAreaPictureBox);
+            this.Controls.Add(this.OverlayLabel);
+			if (true)
+			{
+
+				this.paddingL = new System.Windows.Forms.Label();
+				this.paddingT = new System.Windows.Forms.Label();
+				this.paddingR = new System.Windows.Forms.Label();
+				this.paddingB = new System.Windows.Forms.Label();
+				this.Controls.Add(this.paddingL);
+				this.Controls.Add(this.paddingT);
+				this.Controls.Add(this.paddingR);
+				this.Controls.Add(this.paddingB);
+			}
+            this.Controls.Add(OverlayAreaPictureBox);
 			this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.None;
 			this.MaximizeBox = false;
 			this.MinimizeBox = false;
@@ -82,8 +102,16 @@
 
 		}
 
-		#endregion
+        #endregion
 
-		private System.Windows.Forms.Label OverlayLabel;
-	}
+        private System.Windows.Forms.Label OverlayLabel;
+
+        private System.Windows.Forms.Label paddingL;
+
+        private System.Windows.Forms.Label paddingT;
+
+        private System.Windows.Forms.Label paddingR;
+
+        private System.Windows.Forms.Label paddingB;
+    }
 }

--- a/src/Eve-O-Preview/View/Implementation/ThumbnailOverlay.cs
+++ b/src/Eve-O-Preview/View/Implementation/ThumbnailOverlay.cs
@@ -1,18 +1,28 @@
 ﻿using System;
+using System.Collections.Generic;
+using System.Diagnostics.Eventing.Reader;
+using System.Drawing;
+using System.Linq;
 using System.Windows.Forms;
+using EveOPreview.Configuration;
 using EveOPreview.Services;
 
 namespace EveOPreview.View
 {
 	public partial class ThumbnailOverlay : Form
 	{
+		public bool highlighted;
+
 		#region Private fields
 		private readonly Action<object, MouseEventArgs> _areaClickAction;
-		#endregion
+        private IThumbnailConfiguration _config;
+        #endregion
 
-		public ThumbnailOverlay(Form owner, Action<object, MouseEventArgs> areaClickAction)
+        public ThumbnailOverlay(Form owner, IThumbnailConfiguration config, Action<object, MouseEventArgs> areaClickAction)
 		{
 			this.Owner = owner;
+			this.highlighted = false;
+			this._config = config;
 			this._areaClickAction = areaClickAction;
 
 			InitializeComponent();
@@ -26,9 +36,104 @@ namespace EveOPreview.View
 		public void SetOverlayLabel(string label)
 		{
 			this.OverlayLabel.Text = label;
+        }
+
+		public Color ColorConvertor(string colorSetting)
+		{
+			if(colorSetting == null || colorSetting.Trim().ToLower() == "none" || colorSetting.Trim().ToLower() == "transparent") {
+				return Color.Transparent;
+			}
+
+			if(colorSetting.StartsWith("#"))
+			{
+				if(colorSetting.Length == 9)
+				{
+                    return Color.FromArgb(
+                        Int32.Parse(colorSetting.Substring(1), System.Globalization.NumberStyles.HexNumber)
+                    );
+                }
+				if(colorSetting.Length == 4 ||  colorSetting.Length == 7) {
+					return ColorTranslator.FromHtml(colorSetting);
+                }
+			}
+
+			return Color.Black;
 		}
 
-		public void EnableOverlayLabel(bool enable)
+		public void FormatLabel()
+        {
+            int paddedOffset = this.highlighted ? this._config.PaddingWidthActive : this._config.PaddingWidth;
+            Color paddedColor = this.ColorConvertor(this.highlighted ? this._config.PaddingColorActive : this._config.PaddingColor);
+            Color labelBackgroundColor = this.ColorConvertor(this.highlighted ? this._config.LabelBackgroundActive : this._config.LabelBackground);
+            Color labelForegroundColor = this.ColorConvertor(this.highlighted ? this._config.LabelForegroundActive : this._config.LabelForeground);
+
+			this.OverlayLabel.ForeColor = labelForegroundColor;
+            this.OverlayLabel.BackColor = labelBackgroundColor;
+            this.OverlayLabel.Font = new Font(
+				this._config.LabelFontName,
+				0F + this._config.LabelFontSize,
+				FontStyle.Regular
+			);
+
+            int renderedHeight = TextRenderer.MeasureText(this.OverlayLabel.Text, this.OverlayLabel.Font).Height + paddedOffset;
+            this.OverlayLabel.AutoSize = false;
+            this.OverlayLabel.Height = renderedHeight;
+				/*Math.Max(
+				this._config.ThumbnailSize.Width,
+				this.Owner.ClientSize.Width
+			) - 100;*/
+
+            switch (this._config.LabelHorizontalAlign.ToLower().Trim())
+            {
+                case "left":
+                    this.OverlayLabel.TextAlign = ContentAlignment.TopLeft;
+                    break;
+                case "right":
+					this.OverlayLabel.TextAlign = ContentAlignment.TopRight;
+					break;
+                case "center":
+                    this.OverlayLabel.TextAlign = ContentAlignment.TopCenter;
+                    break;
+            }
+
+            this.OverlayLabel.Width = this.Owner.ClientSize.Width - (paddedOffset * 2);
+            this.OverlayLabel.Location =
+				(this._config.LabelVerticalAlign.ToLower().Trim() == "bottom")
+				? new Point(paddedOffset, this.Owner.ClientSize.Height - renderedHeight - paddedOffset)
+				: new Point(paddedOffset, paddedOffset);
+
+            this.paddingB.Visible = true;
+            this.paddingB.AutoSize = false;
+            this.paddingB.Height = paddedOffset;
+            this.paddingB.Width = this.Owner.ClientSize.Width;
+			this.paddingB.Location = new Point(paddedOffset, this.Owner.ClientSize.Height - paddedOffset);
+            this.paddingB.BackColor = paddedColor;
+
+            this.paddingT.Visible = true;
+            this.paddingT.AutoSize = false;
+            this.paddingT.Height = paddedOffset;
+            this.paddingT.Width = this.Owner.ClientSize.Width;
+            this.paddingT.Location = new Point(paddedOffset, 0);
+            this.paddingT.BackColor = paddedColor;
+
+            this.paddingR.Visible = true;
+            this.paddingR.AutoSize = false;
+			this.paddingR.Height = this.Owner.ClientSize.Height;
+            this.paddingR.Width = paddedOffset;
+            this.paddingR.Location = new Point(this.Owner.ClientSize.Width - paddedOffset, 0);
+            this.paddingR.BackColor = paddedColor;
+
+            this.paddingL.Visible = true;
+            this.paddingL.AutoSize = false;
+            this.paddingL.Height = this.Owner.ClientSize.Height;
+            this.paddingL.Width = paddedOffset;
+			this.paddingL.Location = new Point(0, 0);
+            this.paddingL.BackColor = paddedColor;
+
+            if (this._config.ShowThumbnailOverlays) { this.OverlayLabel.Visible = true; }
+        }
+
+        public void EnableOverlayLabel(bool enable)
 		{
 			this.OverlayLabel.Visible = enable;
 		}

--- a/src/Eve-O-Preview/View/Implementation/ThumbnailView.cs
+++ b/src/Eve-O-Preview/View/Implementation/ThumbnailView.cs
@@ -71,12 +71,13 @@ namespace EveOPreview.View
 
 			InitializeComponent();
 
-			this._overlay = new ThumbnailOverlay(this, this.MouseDown_Handler);
+            this._overlay = new ThumbnailOverlay(this, config, this.MouseDown_Handler);
 
-			this._config = config;
+            this._config = config;
 			SetDefaultBorderColor();
-			this._thumbnailManager = thumbnailManager;
-		}
+            this._thumbnailManager = thumbnailManager;
+            this._overlay.FormatLabel();
+        }
 
 		public IWindowManager WindowManager { get; }
 
@@ -89,6 +90,7 @@ namespace EveOPreview.View
 			{
 				this.Text = value;
 				this._overlay.SetOverlayLabel(value.Replace("EVE - ", ""));
+				this._overlay.FormatLabel();
 				SetDefaultBorderColor();
 			}
 		}
@@ -127,6 +129,7 @@ namespace EveOPreview.View
 
 		public void SetDefaultBorderColor()
 		{
+
 			this._myBorderColor = new Lazy<Color>(() =>
 			{
 				if (this._config.PerClientActiveClientHighlightColor.Any(x => x.Key == this.Title))
@@ -152,7 +155,7 @@ namespace EveOPreview.View
 
 			this.Refresh(true);
 
-			this.IsActive = true;
+            this.IsActive = true;
 		}
 
 		public new void Hide()
@@ -258,14 +261,18 @@ namespace EveOPreview.View
 			}
 
 			if (enabled)
-			{
+            {
+                this._overlay.highlighted = true;
+                this._overlay.FormatLabel();
 				this._isHighlightRequested = true;
 				this._highlightWidth = width;
 				this.BackColor = _myBorderColor.Value;
 			}
 			else
-			{
-				this._isHighlightRequested = false;
+            {
+				this._overlay.highlighted = false;
+                this._overlay.FormatLabel();
+                this._isHighlightRequested = false;
 				this.BackColor = SystemColors.Control;
 			}
 
@@ -370,8 +377,8 @@ namespace EveOPreview.View
 			this.RefreshThumbnail(forceRefresh);
 			this.HighlightThumbnail(forceRefresh || this._isSizeChanged);
 			this.RefreshOverlay(forceRefresh || this._isSizeChanged || this._isLocationChanged);
-
-			this._isSizeChanged = false;
+			this._overlay.FormatLabel();
+            this._isSizeChanged = false;
 		}
 
 		protected abstract void RefreshThumbnail(bool forceRefresh);
@@ -391,7 +398,7 @@ namespace EveOPreview.View
 			int baseWidth = this.ClientSize.Width;
 			int baseHeight = this.ClientSize.Height;
 
-			if (!this._isHighlightRequested)
+			if (!this._isHighlightRequested || (this._config.LabelBackground != this._config.LabelBackgroundActive) || this._config.PaddingWidthActive > 0)
 			{
 				//No highlighting enabled, so no math required
 				this.ResizeThumbnail(baseWidth, baseHeight, 0, 0, 0, 0);
@@ -411,6 +418,8 @@ namespace EveOPreview.View
 
 		private void RefreshOverlay(bool forceRefresh)
 		{
+			this._overlay.FormatLabel();
+
 			if (this._isOverlayVisible && !forceRefresh)
 			{
 				// No need to update anything. Everything is already set up
@@ -425,7 +434,7 @@ namespace EveOPreview.View
 				// Otherwise its position won't be set
 				this._overlay.Show();
 				this._isOverlayVisible = true;
-			}
+            }
 
 			Size overlaySize = this.ClientSize;
 			Point overlayLocation = this.Location;
@@ -538,7 +547,7 @@ namespace EveOPreview.View
 			this.Size = this._baseZoomSize;
 			this.MaximumSize = this._baseZoomMaximumSize;
 			this.Location = this._baseZoomLocation;
-		}
+        }
 
 		private void EnterCustomMouseMode()
 		{

--- a/src/Eve-O-Preview/app.config
+++ b/src/Eve-O-Preview/app.config
@@ -1,3 +1,3 @@
 <?xml version="1.0" encoding="utf-8"?>
 <configuration>
-<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.6.2"/></startup></configuration>
+<startup><supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/></startup></configuration>


### PR DESCRIPTION
I have added the ability to crop thumbnail source (and a few extra cycle hotgroups). For example, I have the following cropped for my Thumbnail view:

![hx5bfvF](https://github.com/EveOPlus/eve-o-preview/assets/839300/29890f20-a7c9-4ccb-8154-9772c3e162b2)

so the preview for this client only looks like this:

![WC8YZur](https://github.com/EveOPlus/eve-o-preview/assets/839300/cbaefab1-8b21-4f71-979b-c172b37c1ac7)

I am not a C# guy so please be gentle.