### PR TITLE
Disable thumbnails when only single account logged in.

### DIFF
--- a/src/Eve-O-Preview/Configuration/Implementation/ThumbnailConfiguration.cs
+++ b/src/Eve-O-Preview/Configuration/Implementation/ThumbnailConfiguration.cs
@@ -53,6 +53,8 @@ namespace EveOPreview.Configuration.Implementation
 			this.EnableActiveClientHighlight = false;
 			this.ActiveClientHighlightColor = Color.GreenYellow;
 			this.ActiveClientHighlightThickness = 3;
+
+			this.HideThumbnailsOnSingleClient = false;
 		}
 
 		public bool MinimizeToTray { get; set; }
@@ -114,8 +116,9 @@ namespace EveOPreview.Configuration.Implementation
 		public bool ShowThumbnailFrames { get; set; }
 
 		public bool EnableActiveClientHighlight { get; set; }
+        public bool HideThumbnailsOnSingleClient { get; set; }
 
-		public Color ActiveClientHighlightColor { get; set; }
+        public Color ActiveClientHighlightColor { get; set; }
 
 		public int ActiveClientHighlightThickness { get; set; }
 

--- a/src/Eve-O-Preview/Configuration/Interface/IThumbnailConfiguration.cs
+++ b/src/Eve-O-Preview/Configuration/Interface/IThumbnailConfiguration.cs
@@ -35,6 +35,7 @@ namespace EveOPreview.Configuration
 		bool ShowThumbnailFrames { get; set; }
 
 		bool EnableActiveClientHighlight { get; set; }
+        bool HideThumbnailsOnSingleClient { get; set; }
 		Color ActiveClientHighlightColor { get; set; }
 		int ActiveClientHighlightThickness { get; set; }
 

--- a/src/Eve-O-Preview/Presenters/Implementation/MainFormPresenter.cs
+++ b/src/Eve-O-Preview/Presenters/Implementation/MainFormPresenter.cs
@@ -122,6 +122,8 @@ namespace EveOPreview.Presenters
 			this.View.ShowThumbnailFrames = this._configuration.ShowThumbnailFrames;
 			this.View.EnableActiveClientHighlight = this._configuration.EnableActiveClientHighlight;
 			this.View.ActiveClientHighlightColor = this._configuration.ActiveClientHighlightColor;
+
+			this.View.HideThumbnailsOnSingleClient = this._configuration.HideThumbnailsOnSingleClient;
 		}
 
 		private async void SaveApplicationSettings()
@@ -152,8 +154,10 @@ namespace EveOPreview.Presenters
 
 			this._configuration.EnableActiveClientHighlight = this.View.EnableActiveClientHighlight;
 			this._configuration.ActiveClientHighlightColor = this.View.ActiveClientHighlightColor;
+			this._configuration.HideThumbnailsOnSingleClient = this.View.HideThumbnailsOnSingleClient;
 
-			this._configurationStorage.Save();
+
+            this._configurationStorage.Save();
 
 			this.View.RefreshZoomSettings();
 

--- a/src/Eve-O-Preview/Services/Implementation/ThumbnailManager.cs
+++ b/src/Eve-O-Preview/Services/Implementation/ThumbnailManager.cs
@@ -97,8 +97,10 @@ namespace EveOPreview.Services
 		private void EnableDisableThumbnails()
 		{
             var characters = _thumbnailViews.Values.ToList();
-			//Need to add logic here depending on whether or not we want the thumbnails to show when login screens are on, up for discussion in pull request
+            //Need to add logic here depending on whether or not we want the thumbnails to show when login screens are on, up for discussion in pull request
             bool refreshEnabled = characters.Count > 1;
+			if (!_configuration.HideThumbnailsOnSingleClient)
+                refreshEnabled = true;
             foreach (var c in characters)
                 _configuration.ToggleThumbnail(c.Title, !refreshEnabled);
         }

--- a/src/Eve-O-Preview/Services/Implementation/ThumbnailManager.cs
+++ b/src/Eve-O-Preview/Services/Implementation/ThumbnailManager.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using System.Collections.Generic;
 using System.Drawing;
+using System.Linq;
 using System.Threading.Tasks;
 using System.Windows.Threading;
 using EveOPreview.Configuration;
@@ -85,9 +86,22 @@ namespace EveOPreview.Services
 
 		private void ThumbnailUpdateTimerTick(object sender, EventArgs e)
 		{
+			this.EnableDisableThumbnails();
 			this.UpdateThumbnailsList();
 			this.RefreshThumbnails();
-		}
+        }
+
+		/// <summary>
+		/// Disables thumbnails if only one account is active
+		/// </summary>
+		private void EnableDisableThumbnails()
+		{
+            var characters = _thumbnailViews.Values.ToList();
+			//Need to add logic here depending on whether or not we want the thumbnails to show when login screens are on, up for discussion in pull request
+            bool refreshEnabled = characters.Count > 1;
+            foreach (var c in characters)
+                _configuration.ToggleThumbnail(c.Title, !refreshEnabled);
+        }
 
 		private async void UpdateThumbnailsList()
 		{

--- a/src/Eve-O-Preview/View/Implementation/MainForm.Designer.cs
+++ b/src/Eve-O-Preview/View/Implementation/MainForm.Designer.cs
@@ -65,7 +65,8 @@ namespace EveOPreview.View
 			this.ShowThumbnailsAlwaysOnTopCheckBox = new System.Windows.Forms.CheckBox();
 			this.HideThumbnailsOnLostFocusCheckBox = new System.Windows.Forms.CheckBox();
 			this.EnablePerClientThumbnailsLayoutsCheckBox = new System.Windows.Forms.CheckBox();
-			this.MinimizeToTrayCheckBox = new System.Windows.Forms.CheckBox();
+            this.HideThumbnailsOnSingleClientCheckBox = new System.Windows.Forms.CheckBox();
+            this.MinimizeToTrayCheckBox = new System.Windows.Forms.CheckBox();
 			this.ThumbnailsWidthNumericEdit = new System.Windows.Forms.NumericUpDown();
 			this.ThumbnailsHeightNumericEdit = new System.Windows.Forms.NumericUpDown();
 			this.ThumbnailOpacityTrackBar = new System.Windows.Forms.TrackBar();
@@ -206,7 +207,8 @@ namespace EveOPreview.View
 			GeneralSettingsPanel.Controls.Add(this.ShowThumbnailsAlwaysOnTopCheckBox);
 			GeneralSettingsPanel.Controls.Add(this.HideThumbnailsOnLostFocusCheckBox);
 			GeneralSettingsPanel.Controls.Add(this.EnablePerClientThumbnailsLayoutsCheckBox);
-			GeneralSettingsPanel.Controls.Add(this.MinimizeToTrayCheckBox);
+            GeneralSettingsPanel.Controls.Add(this.HideThumbnailsOnSingleClientCheckBox);
+            GeneralSettingsPanel.Controls.Add(this.MinimizeToTrayCheckBox);
 			GeneralSettingsPanel.Dock = System.Windows.Forms.DockStyle.Fill;
 			GeneralSettingsPanel.Location = new System.Drawing.Point(3, 3);
 			GeneralSettingsPanel.Name = "GeneralSettingsPanel";
@@ -287,10 +289,23 @@ namespace EveOPreview.View
 			this.EnablePerClientThumbnailsLayoutsCheckBox.Text = "Unique layout for each EVE client";
 			this.EnablePerClientThumbnailsLayoutsCheckBox.UseVisualStyleBackColor = true;
 			this.EnablePerClientThumbnailsLayoutsCheckBox.CheckedChanged += new System.EventHandler(this.OptionChanged_Handler);
-			// 
-			// MinimizeToTrayCheckBox
-			// 
-			this.MinimizeToTrayCheckBox.AutoSize = true;
+            // 
+            // HideThumbnailsOnSingleClient
+            // 
+            this.HideThumbnailsOnSingleClientCheckBox.AutoSize = true;
+            this.HideThumbnailsOnSingleClientCheckBox.Checked = true;
+            this.HideThumbnailsOnSingleClientCheckBox.CheckState = System.Windows.Forms.CheckState.Checked;
+            this.HideThumbnailsOnSingleClientCheckBox.Location = new System.Drawing.Point(8, 176);
+            this.HideThumbnailsOnSingleClientCheckBox.Name = "HideThumbnailsOnSingleClient";
+            this.HideThumbnailsOnSingleClientCheckBox.Size = new System.Drawing.Size(185, 17);
+            this.HideThumbnailsOnSingleClientCheckBox.TabIndex = 24;
+            this.HideThumbnailsOnSingleClientCheckBox.Text = "Hide thumbnails with single client";
+            this.HideThumbnailsOnSingleClientCheckBox.UseVisualStyleBackColor = true;
+            this.HideThumbnailsOnSingleClientCheckBox.CheckedChanged += new System.EventHandler(this.OptionChanged_Handler);
+            // 
+            // MinimizeToTrayCheckBox
+            // 
+            this.MinimizeToTrayCheckBox.AutoSize = true;
 			this.MinimizeToTrayCheckBox.Location = new System.Drawing.Point(8, 7);
 			this.MinimizeToTrayCheckBox.Name = "MinimizeToTrayCheckBox";
 			this.MinimizeToTrayCheckBox.Size = new System.Drawing.Size(139, 17);
@@ -907,7 +922,8 @@ namespace EveOPreview.View
 		private CheckBox ShowThumbnailsAlwaysOnTopCheckBox;
 		private CheckBox HideThumbnailsOnLostFocusCheckBox;
 		private CheckBox EnablePerClientThumbnailsLayoutsCheckBox;
-		private CheckBox MinimizeToTrayCheckBox;
+		private CheckBox HideThumbnailsOnSingleClientCheckBox;
+        private CheckBox MinimizeToTrayCheckBox;
 		private NumericUpDown ThumbnailsWidthNumericEdit;
 		private NumericUpDown ThumbnailsHeightNumericEdit;
 		private TrackBar ThumbnailOpacityTrackBar;

--- a/src/Eve-O-Preview/View/Implementation/MainForm.cs
+++ b/src/Eve-O-Preview/View/Implementation/MainForm.cs
@@ -176,7 +176,12 @@ namespace EveOPreview.View
 				this.ActiveClientHighlightColorButton.BackColor = value;
 			}
 		}
-		private Color _activeClientHighlightColor;
+        public bool HideThumbnailsOnSingleClient
+		{
+            get => this.HideThumbnailsOnSingleClientCheckBox.Checked;
+            set => this.HideThumbnailsOnSingleClientCheckBox.Checked = value;
+        }
+        private Color _activeClientHighlightColor;
 
 		public new void Show()
 		{
@@ -256,10 +261,10 @@ namespace EveOPreview.View
 
 		public Action<string> ThumbnailStateChanged { get; set; }
 
-		public Action DocumentationLinkActivated { get; set; }
+		public Action DocumentationLinkActivated { get; set; }        
 
-		#region UI events
-		private void ContentTabControl_DrawItem(object sender, DrawItemEventArgs e)
+        #region UI events
+        private void ContentTabControl_DrawItem(object sender, DrawItemEventArgs e)
 		{
 			TabControl control = (TabControl)sender;
 			TabPage page = control.TabPages[e.Index];

--- a/src/Eve-O-Preview/View/Interface/IMainFormView.cs
+++ b/src/Eve-O-Preview/View/Interface/IMainFormView.cs
@@ -31,7 +31,9 @@ namespace EveOPreview.View
 		bool ShowThumbnailFrames { get; set; }
 
 		bool EnableActiveClientHighlight { get; set; }
-		Color ActiveClientHighlightColor { get; set; }
+		bool HideThumbnailsOnSingleClient { get; set; }
+
+        Color ActiveClientHighlightColor { get; set; }
 
 		void SetDocumentationUrl(string url);
 		void SetVersionInfo(string version);


### PR DESCRIPTION
Based off master branch, this feature disables thumbnails when only a single account is logged in.

Added an option to the main settings to enable/disable, default is disabled.

Currently a couple questions but should be easily resolved:
1) How to handle accounts that are on character select screen, currently I am counting this as "logged in"
2) Doing the check every tick and setting the enable/disable flag on each thumbnail.  I didn't add a temp bool so we run only if changed, currently it just iterates through each thumbnail and sets the enable disable flag.  Its performing this flag change every 500ms per character and only toggling a bool so I didn't overengineer it here.
3) Please double check my option, this is the first time I've mucked with the UI, but I basically just copied how the other options were implemented.