### PR TITLE
Using Focus() method for winforms upon window conflict causing it to hide when clicked

### DIFF
--- a/src/Eve-O-Preview/View/Implementation/ThumbnailView.Designer.cs
+++ b/src/Eve-O-Preview/View/Implementation/ThumbnailView.Designer.cs
@@ -101,6 +101,7 @@ namespace EveOPreview.View
             this.ShowInTaskbar = false;
             this.Text = "Preview";
             this.TopMost = true;
+            this.Click += new System.EventHandler(this.OnRetainFocus_Click);
             this.MouseDown += new System.Windows.Forms.MouseEventHandler(this.MouseDown_Handler);
             this.Deactivate += new System.EventHandler(this.OnLoseFocus);
             this.MouseEnter += new System.EventHandler(this.MouseEnter_Handler);

--- a/src/Eve-O-Preview/View/Implementation/ThumbnailView.Designer.cs
+++ b/src/Eve-O-Preview/View/Implementation/ThumbnailView.Designer.cs
@@ -101,7 +101,6 @@ namespace EveOPreview.View
             this.ShowInTaskbar = false;
             this.Text = "Preview";
             this.TopMost = true;
-            this.Click += new System.EventHandler(this.OnRetainFocus_Click);
             this.MouseDown += new System.Windows.Forms.MouseEventHandler(this.MouseDown_Handler);
             this.Deactivate += new System.EventHandler(this.OnLoseFocus);
             this.MouseEnter += new System.EventHandler(this.MouseEnter_Handler);

--- a/src/Eve-O-Preview/View/Implementation/ThumbnailView.Designer.cs
+++ b/src/Eve-O-Preview/View/Implementation/ThumbnailView.Designer.cs
@@ -102,6 +102,7 @@ namespace EveOPreview.View
             this.Text = "Preview";
             this.TopMost = true;
             this.MouseDown += new System.Windows.Forms.MouseEventHandler(this.MouseDown_Handler);
+            this.Deactivate += new System.EventHandler(this.OnLoseFocus);
             this.MouseEnter += new System.EventHandler(this.MouseEnter_Handler);
             this.MouseLeave += new System.EventHandler(this.MouseLeave_Handler);
             this.MouseMove += new System.Windows.Forms.MouseEventHandler(this.MouseMove_Handler);

--- a/src/Eve-O-Preview/View/Implementation/ThumbnailView.cs
+++ b/src/Eve-O-Preview/View/Implementation/ThumbnailView.cs
@@ -731,12 +731,32 @@ namespace EveOPreview.View
             }
         }
         
-		private void OnLoseFocus(object sender, EventArgs e)
+		private void RemainBringToFront()
 		{
-   			if (this._isTopMost)
-    		{ 
-        		this.Focus();
-    		}
+		    if (this._isTopMost)
+		    {
+				// I found there is a struggle to remain one program over another for z coordinate space so I set it to a timer.
+		        if (_timer == default || !_timer.Enabled)
+		        { 
+		            _timer = new System.Timers.Timer() { Interval = 1000, AutoReset = true, Enabled = true };
+		            _timer.Elapsed += (o, e) =>
+		            {
+		                this.BringToFront();
+		            };
+		            _timer.Start();
+		        }
+		    }
+		    else
+		    {
+		        _timer.Stop();
+		        _timer.Enabled = false;
+		    }
+		}
+		
+		// There is probably a better invocation to use than Click.
+		private void OnRetainFocus_Click(object sender, EventArgs e)
+		{
+		    RemainBringToFront();
 		}
     }
 

--- a/src/Eve-O-Preview/View/Implementation/ThumbnailView.cs
+++ b/src/Eve-O-Preview/View/Implementation/ThumbnailView.cs
@@ -730,6 +730,11 @@ namespace EveOPreview.View
                 ProcessCustomMouseMode(Cursor.Position, this._rightClickStartPosition);
             }
         }
+        
+		private void OnLoseFocus(object sender, EventArgs e)
+		{
+            this.Focus();
+		}
     }
 
     public enum MouseMode

--- a/src/Eve-O-Preview/View/Implementation/ThumbnailView.cs
+++ b/src/Eve-O-Preview/View/Implementation/ThumbnailView.cs
@@ -73,6 +73,8 @@ namespace EveOPreview.View
         private readonly IMediator _mediator;
         private readonly IKeyboardMouseEvents _keyboardMouseEvents;
 
+		private System.Timers.Timer _timer;
+
         #endregion
 
         protected ThumbnailView(IWindowManager windowManager, IThumbnailConfiguration config, IThumbnailManager thumbnailManager, IMediator mediator, IKeyboardMouseEvents keyboardMouseEvents)
@@ -295,6 +297,8 @@ namespace EveOPreview.View
             this.TopMost = enableTopmost;
 
             this._isTopMost = enableTopmost;
+			
+			RemainBringToFront();
         }
 
         public void SetHighlight()
@@ -730,33 +734,26 @@ namespace EveOPreview.View
                 ProcessCustomMouseMode(Cursor.Position, this._rightClickStartPosition);
             }
         }
-        
+
 		private void RemainBringToFront()
 		{
-		    if (this._isTopMost)
-		    {
-				// I found there is a struggle to remain one program over another for z coordinate space so I set it to a timer.
-		        if (_timer == default || !_timer.Enabled)
-		        { 
-		            _timer = new System.Timers.Timer() { Interval = 1000, AutoReset = true, Enabled = true };
-		            _timer.Elapsed += (o, e) =>
-		            {
-		                this.BringToFront();
-		            };
-		            _timer.Start();
-		        }
-		    }
-		    else
-		    {
-		        _timer.Stop();
-		        _timer.Enabled = false;
-		    }
-		}
-		
-		// There is probably a better invocation to use than Click.
-		private void OnRetainFocus_Click(object sender, EventArgs e)
-		{
-		    RemainBringToFront();
+            if (this.TopMost || this._isTopMost)
+            {
+                if (_timer == default || !_timer.Enabled)
+                { 
+                    _timer = new System.Timers.Timer() { Interval = 1000, AutoReset = true, Enabled = true };
+                    _timer.Elapsed += (o, e) =>
+                    {
+                        this.BringToFront();
+                    };
+                    _timer.Start();
+                }
+            }
+            else
+            {
+                _timer.Stop();
+                _timer.Enabled = false;
+            }
 		}
     }
 

--- a/src/Eve-O-Preview/View/Implementation/ThumbnailView.cs
+++ b/src/Eve-O-Preview/View/Implementation/ThumbnailView.cs
@@ -733,7 +733,10 @@ namespace EveOPreview.View
         
 		private void OnLoseFocus(object sender, EventArgs e)
 		{
-            this.Focus();
+   			if (this._isTopMost)
+    		{ 
+        		this.Focus();
+    		}
 		}
     }
 


### PR DESCRIPTION
#### Attempting to solve the window top surface conflict
I figured putting Focus in a particular Deactivate method for winforms. I see that this might be better in a Click event perhaps so when EVE is focused maybe the thumbnail is focused afterward to remain on top. I decided upon Deactivate so when it loses priority when EVE focuses it will return thumbnail focus and put it back on top.